### PR TITLE
Added Fluentd example on merging log lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ We want examples of as many use cases in this repository as possible! Submit a P
 
 ### Fluentd Examples
 
-* [Handling multi line logs](examples/fluentd/multiline-logs)
+* [Handling multiline logs](examples/fluentd/multiline-logs)
 
 ### Setup for the examples
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ We want examples of as many use cases in this repository as possible! Submit a P
 
 ### Fluentd Examples
 
-TODO
+* [Handling multi line logs](examples/fluentd/multiline-logs)
 
 ### Setup for the examples
 

--- a/examples/fluentd/multiline-logs/Dockerfile
+++ b/examples/fluentd/multiline-logs/Dockerfile
@@ -1,0 +1,19 @@
+# Be sure to update the versions to the ones you require
+FROM fluent/fluentd:v1.7.4-1.0
+
+ADD fluentd.conf /extra.conf
+
+# Use root account to install apk
+USER root
+
+# Below RUN installs the concat and cloudwatch-logs plugin.
+# You may want to adjust these to the plugins you require
+RUN apk add --no-cache --update --virtual .build-deps \
+        sudo build-base ruby-dev \
+ && sudo gem install fluent-plugin-concat \
+ && sudo gem install fluent-plugin-cloudwatch-logs \
+ && sudo gem sources --clear-all \
+ && apk del .build-deps \
+ && rm -rf /tmp/* /var/tmp/* /usr/lib/ruby/gems/*/cache/*.gem
+
+USER fluent

--- a/examples/fluentd/multiline-logs/Dockerfile
+++ b/examples/fluentd/multiline-logs/Dockerfile
@@ -1,7 +1,9 @@
 # Be sure to update the versions to the ones you require
 FROM fluent/fluentd:v1.7.4-1.0
 
-ADD fluentd.conf /extra.conf
+# Required if you're not storing this config on S3.
+# In this case, you need to change the reference in the task definition as well.
+# ADD fluentd.conf /extra.conf
 
 # Use root account to install apk
 USER root

--- a/examples/fluentd/multiline-logs/README.md
+++ b/examples/fluentd/multiline-logs/README.md
@@ -1,19 +1,17 @@
-### FireLens Example: Handling multi line logs with Fluentd
+### FireLens Example: Handling multiline logs with Fluentd
 
 In use cases where your containers do not log json, but plain text, it might happen that the log messages include line breaks (e.g., Stacktraces in Java). You may want to handle these kind of logs in a way that lines are merged until a "real" new log line begins.
 For this task, you can use Firelens with Fluentd to join these logs before sending them off.
 
 You need a Docker image with Fluentd and the [concat plugin](https://github.com/fluent-plugins-nursery/fluent-plugin-concat), as well as additional plugins you may require to further process your logs or send them off (see [Dockerfile](Dockerfile) as an example).
-The config shown in [extra.conf](extra.conf) needs to be included in the Docker image.
-
-To apply this configuration, you need to reference it in your FireLens configuration:
+In this example, the additional config ([extra.conf](extra.conf)) needs to be stored in S3, as referenced in `config-file-value` in the task definition:
 
 ```
 "firelensConfiguration": {
     "type": "fluentd",
     "options": {
-        "config-file-type": "file",
-        "config-file-value": "/extra.conf"
+        "config-file-type": "s3",
+        "config-file-value": "arn:aws:s3:::yourbucket/yourdirectory/extra.conf"
     }
 },
 ```

--- a/examples/fluentd/multiline-logs/README.md
+++ b/examples/fluentd/multiline-logs/README.md
@@ -1,0 +1,49 @@
+### FireLens Example: Handling Multiline logs with Fluentd
+
+In use cases where your containers to not log json, but plain text, it might happen that the log messages include line breaks (e.g., Stacktraces in Java). You may want to handle these kind of logs in a way that lines are merged until a "real" new log line begins.
+For this task, you can use Firelens with Fluentd to join these logs before sending them off.
+
+You need a Docker image with Fluentd and the [concat plugin](https://github.com/fluent-plugins-nursery/fluent-plugin-concat), as well as additional plugins you may require to further process your logs or send them off (see [Dockerfile](Dockerfile) as an example).
+The config shown in [extra.conf](extra.conf) needs to be included in the Docker image.
+
+To apply this configuration, you need to reference it in your FireLens configuration:
+
+```
+"firelensConfiguration": {
+    "type": "fluentd",
+    "options": {
+        "config-file-type": "file",
+        "config-file-value": "/extra.conf"
+    }
+},
+```
+
+This Fluentd configuration will concatinate lines until it encounters a new line matching the provided regex in [extra.conf](extra.conf).
+
+The example here would merge the lines:
+
+```
+2019-04-06 17:48:01.049 some log message with Stack
+                        Stacktrace...
+2019-05-06 17:48:01.049 further log messages with stack traces
+                        Some other stacktrace..
+2019-06-06 17:48:01.049 log lines without stacktrace
+```
+
+to merged lines:
+
+```
+2019-04-06 17:48:01.049 some log message with Stack \n Stacktrace...
+2019-05-06 17:48:01.049 further log messages with stack traces \n Some other stacktrace..
+2019-06-06 17:48:01.049 log lines without stacktrace
+```
+
+Additional configuration for the plugin can be found in the documentation of the [concat plugin](https://github.com/fluent-plugins-nursery/fluent-plugin-concat).
+
+When forwarding these logs to CloudWatch Logs, you can use (CloudWatch Logs Insights)[https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AnalyzingLogData.html] with the following query to see the merged log statements:
+
+```
+fields @timestamp, log
+| sort @timestamp desc
+```
+

--- a/examples/fluentd/multiline-logs/README.md
+++ b/examples/fluentd/multiline-logs/README.md
@@ -1,6 +1,6 @@
-### FireLens Example: Handling Multiline logs with Fluentd
+### FireLens Example: Handling multi line logs with Fluentd
 
-In use cases where your containers to not log json, but plain text, it might happen that the log messages include line breaks (e.g., Stacktraces in Java). You may want to handle these kind of logs in a way that lines are merged until a "real" new log line begins.
+In use cases where your containers do not log json, but plain text, it might happen that the log messages include line breaks (e.g., Stacktraces in Java). You may want to handle these kind of logs in a way that lines are merged until a "real" new log line begins.
 For this task, you can use Firelens with Fluentd to join these logs before sending them off.
 
 You need a Docker image with Fluentd and the [concat plugin](https://github.com/fluent-plugins-nursery/fluent-plugin-concat), as well as additional plugins you may require to further process your logs or send them off (see [Dockerfile](Dockerfile) as an example).

--- a/examples/fluentd/multiline-logs/extra.conf
+++ b/examples/fluentd/multiline-logs/extra.conf
@@ -1,0 +1,6 @@
+<filter app-firelens**>
+  @type concat
+  key log
+  stream_identity_key container_id
+  multiline_start_regexp /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3}/
+</filter>

--- a/examples/fluentd/multiline-logs/task-definition.json
+++ b/examples/fluentd/multiline-logs/task-definition.json
@@ -17,8 +17,8 @@
             "firelensConfiguration": {
                 "type": "fluentd",
                 "options": {
-                    "config-file-type": "file",
-                    "config-file-value": "/extra.conf"
+                    "config-file-type": "s3",
+                    "config-file-value": "arn:aws:s3:::yourbucket/yourdirectory/extra.conf"
                 }
             },
             "name": "log_router"
@@ -40,9 +40,5 @@
     ],
     "memory": "2048",
     "family": "loggingtest",
-    "requiresCompatibilities": [
-        "FARGATE"
-    ],
-    "networkMode": "awsvpc",
     "cpu": "1024"
 }

--- a/examples/fluentd/multiline-logs/task-definition.json
+++ b/examples/fluentd/multiline-logs/task-definition.json
@@ -1,0 +1,48 @@
+{
+    "taskRoleArn": "arn:aws:iam::XXXXX:role/ecsTaskRole",
+    "executionRoleArn": "arn:aws:iam::XXXXX:role/ecsTaskExecutionRole",
+    "containerDefinitions": [
+        {
+            "logConfiguration": {
+                "logDriver": "awslogs",
+                "options": {
+                    "awslogs-group": "firelens-container",
+                    "awslogs-region": "us-east-1",
+                    "awslogs-create-group": "true",
+                    "awslogs-stream-prefix": "firelens"
+                }
+            },
+            "memoryReservation": 50,
+            "image": "XXXXX.dkr.ecr.us-east-1.amazonaws.com/fluentd:latest",
+            "firelensConfiguration": {
+                "type": "fluentd",
+                "options": {
+                    "config-file-type": "file",
+                    "config-file-value": "/extra.conf"
+                }
+            },
+            "name": "log_router"
+        },
+        {
+            "logConfiguration": {
+                "logDriver": "awsfirelens",
+                "options": {
+                    "log_group_name": "my-log-group",
+                    "log_stream_name": "my-log-stream",
+                    "@type": "cloudwatch_logs",
+                    "region": "us-east-1"
+                }
+            },
+            "memoryReservation": 100,
+            "image": "XXXXX.dkr.ecr.us-east-1.amazonaws.com/myApp:latest",
+            "name": "app"
+        }
+    ],
+    "memory": "2048",
+    "family": "loggingtest",
+    "requiresCompatibilities": [
+        "FARGATE"
+    ],
+    "networkMode": "awsvpc",
+    "cpu": "1024"
+}


### PR DESCRIPTION
*Description of changes:*

Added an example showing how multiline logs can be merged with
Fluentd and Firelens in a Fargate setup (will most likely work
for EC2 as well, but I haven't tested it).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
