### PR TITLE
Fix datadog example: `name` => `Name` in README

### DIFF
--- a/examples/fluent-bit/datadog/README.md
+++ b/examples/fluent-bit/datadog/README.md
@@ -8,7 +8,7 @@ AWS recommends that you store sensitive information, like your Datadog API Key u
 "logConfiguration": {
 	"logDriver":"awsfirelens",
 	"options": {
-	   "name": "datadog",
+	   "Name": "datadog",
 	   "apiKey": "<DATADOG_API_KEY>",
 	   "dd_service": "my-httpd-service",
 	   "dd_source": "httpd",


### PR DESCRIPTION
Fixes #12 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
