### PR TITLE
Fix and improve example for DataDog integration

### DIFF
--- a/examples/fluent-bit/datadog/README.md
+++ b/examples/fluent-bit/datadog/README.md
@@ -2,6 +2,8 @@
 
 For documentation on sending your FireLens monitored log data to Datadog Logs, see: [Fluent Bit and Firelens](https://docs.datadoghq.com/integrations/ecs_fargate/#fluent-bit-and-firelens).
 
+For all configuration parameters for Fluent Bit DataDog output plugin, see [DataDog](https://docs.datadoghq.com/integrations/fluentbit/#configuration-parameters) or [Fluent Bit](https://docs.fluentbit.io/manual/output/datadog) documentation.
+
 AWS recommends that you store sensitive information, like your Datadog API Key using [secretOptions](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Secret.html) as shown in the example Task Definition. This is optional; it is also valid to simply specify the API Key in options map:
 
 ```
@@ -9,7 +11,9 @@ AWS recommends that you store sensitive information, like your Datadog API Key u
 	"logDriver":"awsfirelens",
 	"options": {
 	   "Name": "datadog",
-	   "apiKey": "<DATADOG_API_KEY>",
+	   "Host": "http-intake.logs.datadoghq.com",
+	   "TLS": "on",
+	   "apikey": "<DATADOG_API_KEY>",
 	   "dd_service": "my-httpd-service",
 	   "dd_source": "httpd",
 	   "dd_tags": "project:example",

--- a/examples/fluent-bit/datadog/task-definition.json
+++ b/examples/fluent-bit/datadog/task-definition.json
@@ -23,15 +23,17 @@
                  "logDriver":"awsfirelens",
                  "options": {
                     "Name": "datadog",
+                    "Host": "http-intake.logs.datadoghq.com",
+                    "TLS": "on",
                     "dd_service": "my-httpd-service",
                     "dd_source": "httpd",
                     "dd_tags": "project:example",
                     "provider": "ecs"
                 },
-                "secretOptions": {
-                    "name": "apiKey",
+                "secretOptions": [{
+                    "name": "apikey",
                     "valueFrom": "arn:${Partition}:secretsmanager:${Region}:${Account}:secret:${SecretId}"
-                }
+                }]
             },
             "memoryReservation": 100
         }


### PR DESCRIPTION
I had some issues with setting up FireLens integration with DataDog. We are using EU based DataDog application and I couldn't find proper configuration option for a while. So I decided to explicitly add `Host` parameter to the example, as well as enabling `TLS` option which should be enabled by default on plugin level IMO. There was also syntax issue with `secretOptions`.
