### PR TITLE
Modify value of total_file_size in task-definition.json for S3 output plugin.

### DIFF
--- a/examples/fluent-bit/s3/task-definition.json
+++ b/examples/fluent-bit/s3/task-definition.json
@@ -31,7 +31,7 @@
 					"Name": "s3",
 					"region": "us-west-2",
 					"bucket": "your-bucket",
-					"total_file_size": "1M",
+					"total_file_size": "6M",
 					"upload_timeout": "1m"
 				}
 			},


### PR DESCRIPTION
*Issue #39:*

*Description of changes:*
`upload_chunk_size` can not be larger than `total_file_size`, and `upload_chunk_size` must be at least 5,242,880 bytes. So I changed `total_file_size` to 6M.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
