### PR TITLE
Added example for Sematext Logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ We want examples of as many use cases in this repository as possible! Submit a P
 * [New Relic Logs](examples/fluent-bit/newrelic)
 * [Sumo Logic](examples/fluent-bit/sumologic)
 * [SolarWinds Loggly](examples/fluent-bit/solarwinds-loggly)
+* [Sematext Logs](examples/fluent-bit/sematext)
 
 ### Fluentd Examples
 

--- a/examples/fluent-bit/sematext/README.md
+++ b/examples/fluent-bit/sematext/README.md
@@ -1,0 +1,22 @@
+### FireLens Example: Logging to Sematext with Fluent Bit
+
+For documentation on sending your logs from AWS ECS running on either AWS Fargate or AWS EC2 to Sematext Logs, see: [Elastic Container Service (ECS) Logs Integration](https://sematext.com/docs/integration/ecs-logs/).
+
+AWS recommends that you store sensitive information, like your Sematext `LOGS_TOKEN` using [secretOptions](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Secret.html) as shown in the example Task Definition. This is optional; it is also valid to simply specify the `LOGS_TOKEN` in the `logConfiguration`. Note, the `URI` field needs to have a `/` in front of the token:
+
+```json
+"logConfiguration": {
+    "logDriver":"awsfirelens",
+    "options": {
+        "Name": "http",
+        "Match": "*",
+        "Header": "sourceName nginx",
+        "Host": "logs-ecs-receiver.sematext.com",
+        "URI": "/<LOGS_TOKEN>",
+        "Port": "443",
+        "TLS": "on",
+        "Format": "json",
+        "compress": "gzip"
+    }
+},
+```

--- a/examples/fluent-bit/sematext/README.md
+++ b/examples/fluent-bit/sematext/README.md
@@ -20,3 +20,5 @@ AWS recommends that you store sensitive information, like your Sematext `LOGS_TO
     }
 },
 ```
+
+> Note: If you are using the EU region of Sematext, use this Host value: `"Host": "logs-ecs-receiver.eu.sematext.com"`

--- a/examples/fluent-bit/sematext/README.md
+++ b/examples/fluent-bit/sematext/README.md
@@ -21,4 +21,4 @@ AWS recommends that you store sensitive information, like your Sematext `LOGS_TO
 },
 ```
 
-> Note: If you are using the EU region of Sematext, use this Host value: `"Host": "logs-ecs-receiver.eu.sematext.com"`
+**Note: If you are using the EU region of Sematext, use this Host value: `"Host": "logs-ecs-receiver.eu.sematext.com"`**

--- a/examples/fluent-bit/sematext/task-definition.json
+++ b/examples/fluent-bit/sematext/task-definition.json
@@ -1,0 +1,42 @@
+{
+  "family": "firelens-example-sematext",
+  "taskRoleArn": "arn:aws:iam::XXXXXXXXXXXX:role/ecs_task_iam_role",
+  "executionRoleArn": "arn:aws:iam::XXXXXXXXXXXX:role/ecs_task_execution_role",
+  "containerDefinitions": [
+      {
+          "essential": true,
+          "image": "amazon/aws-for-fluent-bit:latest",
+          "name": "log_router",
+          "firelensConfiguration":{
+              "type":"fluentbit",
+              "options":{
+                  "enable-ecs-log-metadata":"true"
+              }
+          },
+          "memoryReservation": 50
+       },
+       {
+           "essential": true,
+           "image": "nginx",
+           "name": "website",
+           "logConfiguration": {
+              "logDriver":"awsfirelens",
+              "options": {
+                  "Name": "http",
+                  "Match": "*",
+                  "Header": "sourceName nginx",
+                  "Host": "logs-ecs-receiver.sematext.com",
+                  "Port": "443",
+                  "TLS": "on",
+                  "Format": "json",
+                  "compress": "gzip"
+              },
+              "secretOptions": [{
+                  "name": "URI",
+                  "valueFrom": "arn:${Partition}:secretsmanager:${Region}:${Account}:secret:${SecretId}"
+              }]
+          },
+          "memoryReservation": 100
+      }
+  ]
+}


### PR DESCRIPTION
*What was added?*

- [x] Example for Sematext Logs

*Description of changes:*
This PR adds an example for using FireLens to send logs to Sematext Logs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
