### PR TITLE
Added example for logstash

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ We want examples of as many use cases in this repository as possible! Submit a P
 * [Sumo Logic](examples/fluent-bit/sumologic)
 * [SolarWinds Loggly](examples/fluent-bit/solarwinds-loggly)
 * [Sematext Logs](examples/fluent-bit/sematext)
+* [Send to Logstash](examples/fluent-bit/logstash)
 
 ### Fluentd Examples
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ We want examples of as many use cases in this repository as possible! Submit a P
 * [Sumo Logic](examples/fluent-bit/sumologic)
 * [SolarWinds Loggly](examples/fluent-bit/solarwinds-loggly)
 * [Sematext Logs](examples/fluent-bit/sematext)
-* [Send to Logstash](examples/fluent-bit/logstash)
+* [Logstash](examples/fluent-bit/logstash)
 
 ### Fluentd Examples
 

--- a/examples/fluent-bit/logstash/README.md
+++ b/examples/fluent-bit/logstash/README.md
@@ -1,0 +1,43 @@
+### FireLens Example: Sending Logs to hosted Logstash with Fluent Bit
+
+You can use Fluent Bit's [HTTP output plugin](https://docs.fluentbit.io/manual/pipeline/outputs/http) to send your container's log to external or aws hosted logstash. 
+
+To know more about Logstash, please refer [here](https://www.elastic.co/logstash) and [here](https://aws.amazon.com/elasticsearch-service/the-elk-stack/logstash/).
+
+Logstash works with different plugins, for logs to be processed and transformed, you'll have to enable http input plugins.
+
+An input plugin enables a specific source of events to be read by Logstash. To read more about input plugin, please refer [here](https://www.elastic.co/guide/en/logstash/current/input-plugins.html).
+
+Logstash configuration example to enable source of events to be read by Logstash, here we have used port 8090 - 
+
+```
+input {
+    beats {
+        port => 5044
+        client_inactivity_timeout => 500
+    }
+    http {
+        port => 8080
+        type => "elb_healthcheck"
+    }
+    http {
+        type => 8090
+        type => "ecs_fluent_bit_logs"
+    }
+}
+```
+
+AWS recommands that you store sensitive information (like the URI containing some sensative token) using [secretOptions](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Secret.html), as shown in this example [task definition](task-definition.json). However using URI is optional and it is also valid to use URI as part of `options` map (URI is optional as part of http output plugin of Fluent Bit):
+
+```
+"logConfiguration": {
+        "logDriver": "awsfirelens",
+        "options": {
+                "Name": "http",
+                "Host": "api.logstash.fake.domain",
+                "URI": "/some/<token>/tag/<tag>/",
+                "Port": "8090",
+                "Format": "json",
+        }
+}
+```

--- a/examples/fluent-bit/logstash/sample_logstash_conf
+++ b/examples/fluent-bit/logstash/sample_logstash_conf
@@ -1,0 +1,22 @@
+input {
+    beats {
+        port => 5044
+        client_inactivity_timeout => 500
+    }
+    http {
+        port => 8080
+        type => "elb_healthcheck"
+    }
+    http {
+        type => 8090
+        type => "ecs_fluent_bit_logs"
+    }
+}
+
+filter {
+    //Filtering Logs Command Here
+}
+
+output {
+    //Output Logs to Desire Destination
+}

--- a/examples/fluent-bit/logstash/task-definition.json
+++ b/examples/fluent-bit/logstash/task-definition.json
@@ -1,0 +1,41 @@
+{
+	"family": "firelens-example-logstash",
+	"taskRoleArn": "arn:aws:iam::XXXXXXXXXXXX:role/serviceTaskRole",
+    "executionRoleArn": "arn:aws:iam::XXXXXXXXXXXX:role/ecsTaskExecutionRole",
+    "networkMode": "awsvpc",
+	"containerDefinitions": [
+		{
+			"essential": true,
+			"image": "906394416424.dkr.ecr.us-east-1.amazonaws.com/aws-for-fluent-bit:latest",
+			"name": "log_router",
+			"firelensConfiguration": {
+				"type": "fluentbit"
+			},
+			"memoryReservation": 50
+		 },
+		 {
+			 "essential": true,
+			 "image": "nginx",
+             "name": "app",
+             "portMappings" : {
+                 "ContainerPort": 443,
+                 "HostPort": 443,
+                 "Protcol": "tcp"
+             },
+			 "logConfiguration": {
+				 "logDriver":"awsfirelens",
+				 "options": {
+					"Name": "http",
+					"Host": "api.logstash.fake.domain",
+					"Port": "8090",
+                    "Format": "json"
+				},
+				"secretOptions": [{
+                    "name": "URI",
+                    "valueFrom": "arn:${Partition}:secretsmanager:${RegionID}:${AccountID}:secret:${SecretId}"
+                }]
+			},
+			"memoryReservation": 100
+		}
+	]
+}

--- a/examples/fluent-bit/logstash/task-definition.json
+++ b/examples/fluent-bit/logstash/task-definition.json
@@ -1,41 +1,43 @@
 {
-	"family": "firelens-example-logstash",
-	"taskRoleArn": "arn:aws:iam::XXXXXXXXXXXX:role/serviceTaskRole",
-    "executionRoleArn": "arn:aws:iam::XXXXXXXXXXXX:role/ecsTaskExecutionRole",
-    "networkMode": "awsvpc",
-	"containerDefinitions": [
-		{
-			"essential": true,
-			"image": "906394416424.dkr.ecr.us-east-1.amazonaws.com/aws-for-fluent-bit:latest",
-			"name": "log_router",
-			"firelensConfiguration": {
-				"type": "fluentbit"
-			},
-			"memoryReservation": 50
-		 },
-		 {
-			 "essential": true,
-			 "image": "nginx",
-             "name": "app",
-             "portMappings" : {
-                 "ContainerPort": 443,
-                 "HostPort": 443,
-                 "Protcol": "tcp"
-             },
-			 "logConfiguration": {
-				 "logDriver":"awsfirelens",
-				 "options": {
-					"Name": "http",
-					"Host": "api.logstash.fake.domain",
-					"Port": "8090",
-                    "Format": "json"
-				},
-				"secretOptions": [{
-                    "name": "URI",
-                    "valueFrom": "arn:${Partition}:secretsmanager:${RegionID}:${AccountID}:secret:${SecretId}"
-                }]
-			},
-			"memoryReservation": 100
-		}
-	]
+    "family":"firelens-example-logstash",
+    "taskRoleArn":"arn:aws:iam::XXXXXXXXXXXX:role/serviceTaskRole",
+    "executionRoleArn":"arn:aws:iam::XXXXXXXXXXXX:role/ecsTaskExecutionRole",
+    "networkMode":"awsvpc",
+    "containerDefinitions":[
+        {
+            "essential":true,
+            "image":"906394416424.dkr.ecr.us-east-1.amazonaws.com/aws-for-fluent-bit:latest",
+            "name":"log_router",
+            "firelensConfiguration":{
+                "type":"fluentbit"
+            },
+            "memoryReservation":50
+        },
+        {
+            "essential":true,
+            "image":"nginx",
+            "name":"app",
+            "portMappings":{
+                "ContainerPort":443,
+                "HostPort":443,
+                "Protcol":"tcp"
+            },
+            "logConfiguration":{
+                "logDriver":"awsfirelens",
+                "options":{
+                    "Name":"http",
+                    "Host":"api.logstash.fake.domain",
+                    "Port":"8090",
+                    "Format":"json"
+                },
+                "secretOptions":[
+                    {
+                        "name":"URI",
+                        "valueFrom":"arn:${Partition}:secretsmanager:${RegionID}:${AccountID}:secret:${SecretId}"
+                    }
+                ]
+            },
+            "memoryReservation":100
+        }
+    ]
 }


### PR DESCRIPTION
**Description of changes:**

Added example for sending logs to the hosted Logstash using `http` plugin of the `fluent-bit`.

This might be helpful for the ones who have their ELK stack already running and with minimal operations they want to achieve logging solutions. 

Here I used example to directly send logs to the logstash.

Open for suggestions, let me know if any correction required.

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
