### PR TITLE
Fix typo in permissions.json that causes ValidationError

### DIFF
--- a/examples/fluent-bit/add-keys/permissions.json
+++ b/examples/fluent-bit/add-keys/permissions.json
@@ -3,7 +3,7 @@
 	"Statement": [{
 		"Effect": "Allow",
 		"Action": [
-			"firehose:PutRecordBatch",
+			"firehose:PutRecordBatch"
 		],
 		"Resource": "*"
 	}]

--- a/examples/fluent-bit/config-file-type-file/permissions.json
+++ b/examples/fluent-bit/config-file-type-file/permissions.json
@@ -3,7 +3,7 @@
 	"Statement": [{
 		"Effect": "Allow",
 		"Action": [
-			"firehose:PutRecordBatch",
+			"firehose:PutRecordBatch"
 		],
 		"Resource": "*"
 	}]

--- a/examples/fluent-bit/kinesis-firehose/permissions.json
+++ b/examples/fluent-bit/kinesis-firehose/permissions.json
@@ -3,7 +3,7 @@
 	"Statement": [{
 		"Effect": "Allow",
 		"Action": [
-			"firehose:PutRecordBatch",
+			"firehose:PutRecordBatch"
 		],
 		"Resource": "*"
 	}]

--- a/examples/fluent-bit/parse-common-log-formats/permissions.json
+++ b/examples/fluent-bit/parse-common-log-formats/permissions.json
@@ -3,7 +3,7 @@
 	"Statement": [{
 		"Effect": "Allow",
 		"Action": [
-			"firehose:PutRecordBatch",
+			"firehose:PutRecordBatch"
 		],
 		"Resource": "*"
 	}]

--- a/examples/fluent-bit/parse-json/permissions.json
+++ b/examples/fluent-bit/parse-json/permissions.json
@@ -3,7 +3,7 @@
 	"Statement": [{
 		"Effect": "Allow",
 		"Action": [
-			"firehose:PutRecordBatch",
+			"firehose:PutRecordBatch"
 		],
 		"Resource": "*"
 	}]

--- a/examples/fluent-bit/s3/permissions.json
+++ b/examples/fluent-bit/s3/permissions.json
@@ -3,7 +3,7 @@
 	"Statement": [{
 		"Effect": "Allow",
 		"Action": [
-			"s3:PutObject",
+			"s3:PutObject"
 		],
 		"Resource": "*"
 	}]

--- a/examples/fluent-bit/send-to-multiple-destinations/permissions.json
+++ b/examples/fluent-bit/send-to-multiple-destinations/permissions.json
@@ -3,7 +3,7 @@
 	"Statement": [{
 		"Effect": "Allow",
 		"Action": [
-			"firehose:PutRecordBatch",
+			"firehose:PutRecordBatch"
 		],
 		"Resource": "*"
 	}]


### PR DESCRIPTION
*Description of changes:*

Permissions.json files cause ValidationError when trying to create a policy. The response from the AWS CLI is `An error occurred (MalformedPolicyDocument) when calling the CreatePolicy operation: Syntax errors in policy.`. I then took the JSON and pasted in AWS management console and immediately it flagged the extra `,` in the JSON.
![image](https://user-images.githubusercontent.com/76068536/116273479-c4be6880-a74f-11eb-865c-7049a9a214ba.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
