### PR TITLE
Add retry_limit to firelens logConfiguration options

### DIFF
--- a/examples/fluent-bit/add-keys/task-definition.json
+++ b/examples/fluent-bit/add-keys/task-definition.json
@@ -30,17 +30,18 @@
 				}
 			],
 			"memoryReservation": 50
-		 },
-		 {
+		},
+		{
 			 "essential": true,
 			 "image": "httpd",
 			 "name": "app",
 			 "logConfiguration": {
 				 "logDriver":"awsfirelens",
 				 "options": {
-					"Name": "firehose",
+					"Name": "kinesis_firehose",
 					"region": "us-west-2",
-					"delivery_stream": "my-stream"
+					"delivery_stream": "my-stream",
+					"retry_limit": "2"
 				}
 			},
 			"memoryReservation": 100

--- a/examples/fluent-bit/amazon-opensearch/task-definition.json
+++ b/examples/fluent-bit/amazon-opensearch/task-definition.json
@@ -20,8 +20,8 @@
 				}
 			},
 			"memoryReservation": 50
-		 },
-		 {
+		},
+		{
 			 "essential": true,
 			 "image": "nginx",
 			 "name": "app",
@@ -35,7 +35,8 @@
 					"Type": "my_type",
 					"Aws_Auth": "On",
 					"Aws_Region": "us-west-2",
-					"tls": "On"
+					"tls": "On",
+					"retry_limit": "2"
 				}
 			},
 			"memoryReservation": 100

--- a/examples/fluent-bit/cloudwatchlogs/README.md
+++ b/examples/fluent-bit/cloudwatchlogs/README.md
@@ -15,7 +15,8 @@ By default, FireLens will send a JSON event with the raw log line encapsulated i
 			"log_key": "log",
 			"log_group_name": "/aws/ecs/containerinsights/$(ecs_cluster)/application",
 			"auto_create_group": "true",
-			"log_stream_name": "$(ecs_task_id)"
+			"log_stream_name": "$(ecs_task_id)",
+			"retry_limit": "2"
 		}
 	},
 ```

--- a/examples/fluent-bit/cloudwatchlogs/task-definition.json
+++ b/examples/fluent-bit/cloudwatchlogs/task-definition.json
@@ -20,19 +20,20 @@
 				}
 			},
 			"memoryReservation": 50
-		 },
-		 {
+		},
+		{
 			 "essential": true,
 			 "image": "nginx",
 			 "name": "app",
 			 "logConfiguration": {
-				 "logDriver":"awsfirelens",
-				 "options": {
+				"logDriver":"awsfirelens",
+				"options": {
 					"Name": "cloudwatch",
 					"region": "us-west-2",
 					"log_group_name": "/aws/ecs/containerinsights/$(ecs_cluster)/application",
 					"auto_create_group": "true",
-					"log_stream_name": "$(ecs_task_id)"
+					"log_stream_name": "$(ecs_task_id)",
+					"retry_limit": "2"
 				}
 			},
 			"memoryReservation": 100

--- a/examples/fluent-bit/config-file-type-file/task-definition.json
+++ b/examples/fluent-bit/config-file-type-file/task-definition.json
@@ -40,7 +40,8 @@
 				 "options": {
 					"Name": "firehose",
 					"region": "us-west-2",
-					"delivery_stream": "my-stream"
+					"delivery_stream": "my-stream",
+					"retry_limit": "2"
 				}
 			},
 			"memoryReservation": 100

--- a/examples/fluent-bit/datadog/README.md
+++ b/examples/fluent-bit/datadog/README.md
@@ -17,7 +17,8 @@ AWS recommends that you store sensitive information, like your Datadog API Key u
 	   "dd_service": "my-httpd-service",
 	   "dd_source": "httpd",
 	   "dd_tags": "project:example",
-	   "provider": "ecs"
+	   "provider": "ecs",
+	   "retry_limit": "2"
    }
 },
 ```

--- a/examples/fluent-bit/datadog/task-definition.json
+++ b/examples/fluent-bit/datadog/task-definition.json
@@ -20,15 +20,16 @@
              "image": "httpd",
              "name": "app",
              "logConfiguration": {
-                 "logDriver":"awsfirelens",
-                 "options": {
+                "logDriver":"awsfirelens",
+                "options": {
                     "Name": "datadog",
                     "Host": "http-intake.logs.datadoghq.com",
                     "TLS": "on",
                     "dd_service": "my-httpd-service",
                     "dd_source": "httpd",
                     "dd_tags": "project:example",
-                    "provider": "ecs"
+                    "provider": "ecs",
+                    "retry_limit": "2"
                 },
                 "secretOptions": [{
                     "name": "apikey",

--- a/examples/fluent-bit/ecs-log-collection/README.md
+++ b/examples/fluent-bit/ecs-log-collection/README.md
@@ -47,6 +47,7 @@ First, we create our Fluent Bit configuration file:
     log_group_name firelens-tutorial-$(ecs_cluster)
     log_stream_name /logs/app/$(ec2_instance_id)-$(ecs_task_id)
     auto_create_group true
+    retry_limit 2
 
 # Output for the file logs
 [OUTPUT]
@@ -56,6 +57,7 @@ First, we create our Fluent Bit configuration file:
     log_group_name firelens-tutorial-$(ecs_cluster)
     log_stream_name /logs/service/$(ec2_instance_id)-$(ecs_task_id)
     auto_create_group true
+    retry_limit 2
 ```
 
 With this output, you will get all of your logs in a single log group with log stream names that tell you whether they came from stdout or the service log file. All log streams will have the EC2 instance ID and ECS Task ID. You can of course modify these patterns to suit your own needs.
@@ -100,6 +102,7 @@ If you wish to run on Fargate, then use the Fluent Bit configuration below which
     log_group_name firelens-tutorial-$(ecs_cluster)
     log_stream_name /logs/app/$(ecs_task_id)
     auto_create_group true
+    retry_limit 2
 
 # Output for the file logs
 [OUTPUT]
@@ -109,6 +112,7 @@ If you wish to run on Fargate, then use the Fluent Bit configuration below which
     log_group_name firelens-tutorial-$(ecs_cluster)
     log_stream_name /logs/service/$(ecs_task_id)
     auto_create_group true
+    retry_limit 2
 ```
 
 Finally, with Fargate you can not store your configuration file in S3. You must bake it into a custom Fluent Bit image. Instructions can be found in the [tutorial in this repo](https://github.com/aws-samples/amazon-ecs-firelens-examples/tree/mainline/examples/fluent-bit/config-file-type-file).
@@ -148,6 +152,7 @@ Your Fluent Bit configuration file should look like the following:
     log_group_name firelens-tutorial-$(ecs_cluster)
     log_stream_name /logs/$(ec2_instance_id)-$(ecs_task_id)
     auto_create_group true
+    retry_limit 2
 ```
 
 Upload this file to S3 and reference it in your FireLens configuration:

--- a/examples/fluent-bit/ecs-log-collection/task-definition-tail.json
+++ b/examples/fluent-bit/ecs-log-collection/task-definition-tail.json
@@ -32,17 +32,17 @@
 			"memoryReservation": 50
 		 },
 		 {
-			 "essential": true,
-			 "image": "my-app:latest",
-			 "name": "app",
-			 "mountPoints" : [
+			"essential": true,
+			"image": "my-app:latest",
+			"name": "app",
+			"mountPoints": [
  				{
- 					"containerPath" : "/var/log/",
- 					"sourceVolume" : "var-log"
+ 					"containerPath": "/var/log/",
+ 					"sourceVolume": "var-log"
  				}
  			],
-			 "logConfiguration": {
-				 "logDriver":"awsfirelens",
+			"logConfiguration": {
+				"logDriver":"awsfirelens"
 			},
 			"memoryReservation": 100
 		}

--- a/examples/fluent-bit/ecs-log-collection/task-definition-tcp.json
+++ b/examples/fluent-bit/ecs-log-collection/task-definition-tcp.json
@@ -24,13 +24,13 @@
 				}
 			},
 			"memoryReservation": 50
-		 },
-		 {
-			 "essential": true,
-			 "image": "my-app:latest",
-			 "name": "app",
-			 "logConfiguration": {
-				 "logDriver":"awsfirelens",
+		},
+		{
+			"essential": true,
+			"image": "my-app:latest",
+			"name": "app",
+			"logConfiguration": {
+				"logDriver":"awsfirelens"
 			},
 			"memoryReservation": 100
 		}

--- a/examples/fluent-bit/efs/extra.conf
+++ b/examples/fluent-bit/efs/extra.conf
@@ -3,3 +3,4 @@
     Match *
     region us-east-1
     delivery_stream my-stream
+    retry_limit 2

--- a/examples/fluent-bit/elastic-cloud/README.md
+++ b/examples/fluent-bit/elastic-cloud/README.md
@@ -16,7 +16,8 @@ This is optional; it is also valid to simply specify the Cloud_Auth in options m
         "Cloud_Auth": "<elasticsearch_username>:<elasticsearch_password>",
         "Index": "elastic_firelens",
         "tls": "On",
-        "tls.verify": "Off"
+        "tls.verify": "Off",
+        "retry_limit": "2"
     }
 },
 ```
@@ -34,7 +35,8 @@ This is optional; you can also use regular Elasticsearch credentials to connect 
         "HTTP_Passwd": "<elasticsearch_password>",
         "Index": "elastic_firelens",
         "tls": "On",
-        "tls.verify": "Off"
+        "tls.verify": "Off",
+        "retry_limit": "2"
     }
 },
 ```

--- a/examples/fluent-bit/elastic-cloud/task-definition.json
+++ b/examples/fluent-bit/elastic-cloud/task-definition.json
@@ -50,7 +50,8 @@
             "Cloud_ID": "<elastic_cloud_id>",
             "Index": "elastic_firelens",
             "tls": "On",
-            "tls.verify": "Off"
+            "tls.verify": "Off",
+            "retry_limit": "2"
           }
         },
         "memoryReservation": 100

--- a/examples/fluent-bit/enable-debug-logging/task-definition.json
+++ b/examples/fluent-bit/enable-debug-logging/task-definition.json
@@ -27,19 +27,20 @@
 				}
 			},
 			"memoryReservation": 50
-		 },
-		 {
-			 "essential": true,
-			 "image": "nginx",
-			 "name": "app",
-			 "logConfiguration": {
-				 "logDriver":"awsfirelens",
-				 "options": {
+		},
+		{
+			"essential": true,
+			"image": "nginx",
+			"name": "app",
+			"logConfiguration": {
+				"logDriver":"awsfirelens",
+				"options": {
 					"Name": "cloudwatch",
 					"region": "us-west-2",
 					"log_group_name": "firelens-fluent-bit",
 					"auto_create_group": "true",
-					"log_stream_prefix": "from-fluent-bit"
+					"log_stream_prefix": "from-fluent-bit",
+					"retry_limit": "2"
 				}
 			},
 			"memoryReservation": 100

--- a/examples/fluent-bit/filter-multiline/task-definition.json
+++ b/examples/fluent-bit/filter-multiline/task-definition.json
@@ -26,17 +26,18 @@
 			"memoryReservation": 50
 		 },
 		 {
-			 "essential": true,
-			 "image": "111111111111.dkr.ecr.us-west-2.amazonaws.com/multiline-example-app:latest",
-			 "name": "app",
-			 "logConfiguration": {
-				 "logDriver":"awsfirelens",
-				 "options": {
+			"essential": true,
+			"image": "111111111111.dkr.ecr.us-west-2.amazonaws.com/multiline-example-app:latest",
+			"name": "app",
+			"logConfiguration": {
+				"logDriver":"awsfirelens",
+				"options": {
 					"Name": "cloudwatch_logs",
 					"region": "us-west-2",
 					"log_group_name": "multiline-test/application",
 					"auto_create_group": "true",
-					"log_stream_prefix": "multiline-"
+					"log_stream_prefix": "multiline-",
+					"retry_limit": "2"
 				}
 			},
 			"memoryReservation": 100

--- a/examples/fluent-bit/forward-to-aggregator/task-definition.json
+++ b/examples/fluent-bit/forward-to-aggregator/task-definition.json
@@ -29,7 +29,8 @@
 				 "options": {
 					"Name": "forward",
 					"Host": "fluentdhost",
-					"Port": "24224"
+					"Port": "24224",
+					"Retry_Limit": "2"
 				}
 			},
 			"memoryReservation": 100

--- a/examples/fluent-bit/kinesis-firehose/task-definition.json
+++ b/examples/fluent-bit/kinesis-firehose/task-definition.json
@@ -20,8 +20,8 @@
 				}
 			},
 			"memoryReservation": 50
-		 },
-		 {
+		},
+		{
 			 "essential": true,
 			 "image": "httpd",
 			 "name": "app",
@@ -30,7 +30,8 @@
 				 "options": {
 					"Name": "firehose",
 					"region": "us-west-2",
-					"delivery_stream": "my-stream"
+					"delivery_stream": "my-stream",
+					"retry_limit": "2"
 				}
 			},
 			"memoryReservation": 100

--- a/examples/fluent-bit/kinesis-stream/task-definition.json
+++ b/examples/fluent-bit/kinesis-stream/task-definition.json
@@ -20,8 +20,8 @@
 				}
 			},
 			"memoryReservation": 50
-		 },
-		 {
+		},
+		{
 			 "essential": true,
 			 "image": "httpd",
 			 "name": "app",
@@ -30,7 +30,8 @@
 				 "options": {
 					"Name": "kinesis_streams",
 					"region": "us-west-2",
-					"stream": "my-data-stream"
+					"stream": "my-data-stream",
+					"retry_limit": "2"
 				}
 			},
 			"memoryReservation": 100

--- a/examples/fluent-bit/log-driver-buffer-limit/README.md
+++ b/examples/fluent-bit/log-driver-buffer-limit/README.md
@@ -22,7 +22,8 @@ By default, the buffer limit will be set to `1MiB`. In order to increase or decr
 			"log_group_name": "/aws/ecs/containerinsights/$(ecs_cluster)/application",
 			"auto_create_group": "true",
 			"log_stream_name": "$(ecs_task_id)",
-			"log-driver-buffer-limit": "2097152"
+			"log-driver-buffer-limit": "2097152",
+			"retry_limit": "2"
 		}
 	},
 ```

--- a/examples/fluent-bit/log-driver-buffer-limit/task-definition.json
+++ b/examples/fluent-bit/log-driver-buffer-limit/task-definition.json
@@ -33,7 +33,8 @@
 					"log_group_name": "/aws/ecs/containerinsights/$(ecs_cluster)/application",
 					"auto_create_group": "true",
 					"log_stream_name": "$(ecs_task_id)",
-					"log-driver-buffer-limit": "2097152"
+					"log-driver-buffer-limit": "2097152",
+					"retry_limit": "2"
 				}
 			},
 			"memoryReservation": 100

--- a/examples/fluent-bit/logstash/README.md
+++ b/examples/fluent-bit/logstash/README.md
@@ -38,6 +38,7 @@ AWS recommands that you store sensitive information (like the URI containing som
                 "URI": "/some/<token>/tag/<tag>/",
                 "Port": "8090",
                 "Format": "json",
+                "Retry_Limit": "2"
         }
 }
 ```

--- a/examples/fluent-bit/logstash/task-definition.json
+++ b/examples/fluent-bit/logstash/task-definition.json
@@ -28,7 +28,8 @@
                     "Name":"http",
                     "Host":"api.logstash.fake.domain",
                     "Port":"8090",
-                    "Format":"json"
+                    "Format":"json",
+                    "Retry_Limit": "2"
                 },
                 "secretOptions":[
                     {

--- a/examples/fluent-bit/newrelic/example-task-definition.json
+++ b/examples/fluent-bit/newrelic/example-task-definition.json
@@ -30,7 +30,8 @@
       "logConfiguration": {
         "logDriver": "awsfirelens",
         "options": {
-          "Name": "newrelic"
+          "Name": "newrelic",
+          "Retry_Limit": "2"
         },
         "secretOptions": [
           {

--- a/examples/fluent-bit/parse-common-log-formats/task-definition.json
+++ b/examples/fluent-bit/parse-common-log-formats/task-definition.json
@@ -34,7 +34,8 @@
 				 "options": {
 					"Name": "firehose",
 					"region": "us-west-2",
-					"delivery_stream": "my-stream"
+					"delivery_stream": "my-stream",
+					"retry_limit": "2"
 				}
 			},
 			"memoryReservation": 100

--- a/examples/fluent-bit/parse-envoy-app-mesh/appmesh-firelens-colorteller-black-ecs-task-def.json
+++ b/examples/fluent-bit/parse-envoy-app-mesh/appmesh-firelens-colorteller-black-ecs-task-def.json
@@ -113,7 +113,8 @@
             "region": "us-east-1",
             "log_group_name": "appmesh-firelens",
             "auto_create_group": "true",
-            "log_stream_prefix": "envoy-black-"
+            "log_stream_prefix": "envoy-black-",
+            "retry_limit": "2"
           }
         },
         "healthCheck": {

--- a/examples/fluent-bit/parse-json/task-definition.json
+++ b/examples/fluent-bit/parse-json/task-definition.json
@@ -24,17 +24,18 @@
 				}
 			},
 			"memoryReservation": 50
-		 },
-		 {
-			 "essential": true,
-			 "image": "httpd",
-			 "name": "app",
-			 "logConfiguration": {
-				 "logDriver":"awsfirelens",
-				 "options": {
+		},
+		{
+			"essential": true,
+			"image": "httpd",
+			"name": "app",
+			"logConfiguration": {
+				"logDriver":"awsfirelens",
+				"options": {
 					"Name": "firehose",
 					"region": "us-west-2",
-					"delivery_stream": "my-stream"
+					"delivery_stream": "my-stream",
+					"retry_limit": "2"
 				}
 			},
 			"memoryReservation": 100

--- a/examples/fluent-bit/s3/task-definition.json
+++ b/examples/fluent-bit/s3/task-definition.json
@@ -20,20 +20,21 @@
 				}
 			},
 			"memoryReservation": 50
-		 },
-		 {
-			 "essential": true,
-			 "image": "httpd",
-			 "name": "app",
-			 "logConfiguration": {
-				 "logDriver":"awsfirelens",
-				 "options": {
+		},
+		{
+			"essential": true,
+			"image": "httpd",
+			"name": "app",
+			"logConfiguration": {
+				"logDriver":"awsfirelens",
+				"options": {
 					"Name": "s3",
 					"region": "us-west-2",
 					"bucket": "your-bucket",
 					"total_file_size": "1M",
 					"upload_timeout": "1m",
-					"use_put_object": "On"
+					"use_put_object": "On",
+					"retry_limit": "2"
 				}
 			},
 			"memoryReservation": 100

--- a/examples/fluent-bit/sematext/README.md
+++ b/examples/fluent-bit/sematext/README.md
@@ -16,7 +16,8 @@ AWS recommends that you store sensitive information, like your Sematext `LOGS_TO
         "Port": "443",
         "TLS": "on",
         "Format": "json",
-        "compress": "gzip"
+        "Compress": "gzip",
+        "Retry_Limit": "2"
     }
 },
 ```

--- a/examples/fluent-bit/sematext/task-definition.json
+++ b/examples/fluent-bit/sematext/task-definition.json
@@ -29,7 +29,8 @@
                   "Port": "443",
                   "TLS": "on",
                   "Format": "json",
-                  "compress": "gzip"
+                  "compress": "gzip",
+                  "retry_limit": "2"
               },
               "secretOptions": [{
                   "name": "URI",

--- a/examples/fluent-bit/send-fb-internal-metrics-to-cw/extra.conf
+++ b/examples/fluent-bit/send-fb-internal-metrics-to-cw/extra.conf
@@ -54,3 +54,4 @@
     log_group_name ${FLUENT_BIT_METRICS_LOG_GROUP}
     log_stream_name ${HOSTNAME}-fb-metrics-prom-format
     auto_create_group On
+    retry_limit 2

--- a/examples/fluent-bit/send-to-multiple-destinations/extra.conf
+++ b/examples/fluent-bit/send-to-multiple-destinations/extra.conf
@@ -3,9 +3,11 @@
     Match  *
     region us-west-2
     delivery_stream stream-one
+    retry_limit 2
 
 [OUTPUT]
     Name   firehose
     Match  *
     region us-west-2
     delivery_stream stream-two
+    retry_limit 2

--- a/examples/fluent-bit/send-to-multiple-destinations/task-definition.json
+++ b/examples/fluent-bit/send-to-multiple-destinations/task-definition.json
@@ -24,13 +24,13 @@
 				}
 			},
 			"memoryReservation": 50
-		 },
-		 {
-			 "essential": true,
-			 "image": "httpd",
-			 "name": "app",
-			 "logConfiguration": {
-				 "logDriver":"awsfirelens"
+		},
+		{
+			"essential": true,
+			"image": "httpd",
+			"name": "app",
+			"logConfiguration": {
+				"logDriver":"awsfirelens"
 			},
 			"memoryReservation": 100
 		}

--- a/examples/fluent-bit/signalfx/task-definition.json
+++ b/examples/fluent-bit/signalfx/task-definition.json
@@ -25,7 +25,8 @@
                     "Name": "SignalFx",
                     "MetricName": "com.firelens.example",
                     "MetricType": "counter",
-                    "Dimensions": "ecs_cluster, container_name"
+                    "Dimensions": "ecs_cluster, container_name",
+                    "Retry_Limit": "2"
                 },
                 "secretOptions": {
                     "name": "Token",

--- a/examples/fluent-bit/sumologic/README.md
+++ b/examples/fluent-bit/sumologic/README.md
@@ -14,7 +14,8 @@ AWS recommends that you store sensitive information (like your Sumologic URI) us
 		"Port": "443",
 		"tls": "on",
 		"tls.verify": "off",
-		"Format": "json_lines"
+		"Format": "json_lines",
+		"Retry_Limit": "2"
 	}
 }
 ```

--- a/examples/splitting-log-streams/fluent-bit/custom-fluent-bit-image/fluent-bit.conf
+++ b/examples/splitting-log-streams/fluent-bit/custom-fluent-bit-image/fluent-bit.conf
@@ -16,3 +16,4 @@
     log_group_name streams-example
     log_stream_prefix log-level-
     auto_create_group true
+    retry_limit 2

--- a/examples/splitting-log-streams/fluent-bit/task_definition.json
+++ b/examples/splitting-log-streams/fluent-bit/task_definition.json
@@ -31,8 +31,8 @@
 				}
 			},
 			"memoryReservation": 100
-		 },
-		 {
+		},
+		{
 			 "essential": true,
 			 "image": "012345678910.dkr.ecr.ap-south-1.amazonaws.com/multi-streams-logger:latest",
 			 "name": "app",


### PR DESCRIPTION
A few changes to the example task definitions:
- Firehose plugin to kinesis_firehose plugin
- Fix formatting of task definitions
- Add retry_limit: 2 option to all task definition outputs

Signed-off-by: Matthew Fala <falamatt@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
