### PR TITLE
Fix space issue in curl command during health check

### DIFF
--- a/examples/fluent-bit/health-check/task-definition-output-metrics-healthcheck.json
+++ b/examples/fluent-bit/health-check/task-definition-output-metrics-healthcheck.json
@@ -18,7 +18,7 @@
 				"retries": 2,
 				"command": [
 					"CMD-SHELL",
-					"curl - f http://127.0.0.1:2020/api/v1/health || exit 1"
+					"curl -f http://127.0.0.1:2020/api/v1/health || exit 1"
 				],
 				"timeout": 5,
 				"interval": 10,


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-samples/amazon-ecs-firelens-examples/issues/76

*Description of changes:*
Removing space from curl command during health check. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
