### PR TITLE
Elastic Cloud integration - illegal_argument_exception error

### DIFF
--- a/examples/fluent-bit/elastic-cloud/README.md
+++ b/examples/fluent-bit/elastic-cloud/README.md
@@ -17,7 +17,8 @@ This is optional; it is also valid to simply specify the Cloud_Auth in options m
         "Index": "elastic_firelens",
         "tls": "On",
         "tls.verify": "Off",
-        "retry_limit": "2"
+        "retry_limit": "2",
+        "Suppress_Type_Name": "On"
     }
 },
 ```
@@ -36,7 +37,8 @@ This is optional; you can also use regular Elasticsearch credentials to connect 
         "Index": "elastic_firelens",
         "tls": "On",
         "tls.verify": "Off",
-        "retry_limit": "2"
+        "retry_limit": "2",
+        "Suppress_Type_Name": "On"
     }
 },
 ```

--- a/examples/fluent-bit/elastic-cloud/task-definition.json
+++ b/examples/fluent-bit/elastic-cloud/task-definition.json
@@ -51,7 +51,8 @@
             "Index": "elastic_firelens",
             "tls": "On",
             "tls.verify": "Off",
-            "retry_limit": "2"
+            "retry_limit": "2",
+            "Suppress_Type_Name": "On"
           }
         },
         "memoryReservation": 100


### PR DESCRIPTION
*Description of changes:*

With the actual task definition, there is an error when the service starts running.

<img width="1058" alt="Screenshot 2023-07-19 at 21 35 59" src="https://github.com/aws-samples/amazon-ecs-firelens-examples/assets/33383393/4b01586d-302f-4055-8a8e-e2e8c0fd596b">

https://docs.fluentbit.io/manual/pipeline/outputs/elasticsearch#action-metadata-contains-an-unknown-parameter-type

It seems that setting `"Suppress_Type_Name": "On"` resolves the issue.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.