### PR TITLE
remove parsers_multiline.conf from Dockerfile

### DIFF
--- a/examples/fluent-bit/filter-multiline-partial-message-mode/custom-fluent-bit-with-config/Dockerfile
+++ b/examples/fluent-bit/filter-multiline-partial-message-mode/custom-fluent-bit-with-config/Dockerfile
@@ -1,4 +1,3 @@
 FROM public.ecr.aws/aws-observability/aws-for-fluent-bit:latest
 
-ADD parsers_multiline.conf /parsers_multiline.conf
 ADD extra.conf /extra.conf


### PR DESCRIPTION
*Issue #, if available:*

Closes #120

*Description of changes:*

Removes unneeded `ADD` from Dockerfile.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
