### PR TITLE
2.32.0 prometheus cw

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ An [init tag](https://github.com/aws/aws-for-fluent-bit#using-the-init-tag) is d
 * [Send to S3](examples/fluent-bit/s3)
 * [Send to Amazon OpenSearch Service](examples/fluent-bit/amazon-opensearch)
 * [Send to Amazon OpenSearch Serverless Service](examples/fluent-bit/amazon-opensearch-serverless)
+* [Send to Amazon Managed Service for Prometheus](examples/fluent-bit/amazon-managed-service-for-prometheus)
 * [Enable Debug Logging](examples/fluent-bit/enable-debug-logging)
 * [Forward to a Fluentd or Fluent Bit Log Aggregator](examples/fluent-bit/forward-to-aggregator)
 * [Parse Serialized JSON](examples/fluent-bit/parse-json)

--- a/examples/fluent-bit/amazon-managed-service-for-prometheus/README.md
+++ b/examples/fluent-bit/amazon-managed-service-for-prometheus/README.md
@@ -1,0 +1,53 @@
+## FireLens Example: Prometheus forward metrics - using the Fluent Bit image with init tag
+
+This example shows how to forward metrics with Fluent Bit's prometheus remote write output plugin to an Amazon Managed Service for Prometheus workspace.
+
+### Step 1: Create config file locally
+
+**fluent-bit.conf**
+
+```
+# FireLens Example: Prometheus forward metrics - using the Fluent Bit image with init tag
+
+# Scape node metrics every 20 seconds (use any metrics input plugin)
+[INPUT]
+    Name                        node_exporter_metrics
+    Tag                         node_metrics
+    Scrape_interval             20
+
+# Send metrics to AMP via Remote Write
+[OUTPUT]
+    Name prometheus_remote_write
+    Match node_metrics
+    Host aps-workspaces.us-west-2.amazonaws.com
+    Port 443
+    Uri /workspaces/< my-amp-workspace-id >/api/v1/remote_write
+    AWS_Auth On
+    AWS_region us-west-2
+    Tls On
+    Tls.verify On
+    add_label app my-ecs-app
+    add_label color blue
+```
+
+**Note:** you can find this config file in the `config-files` directory of this example, please modify according to the actual situation to match your needs.
+
+### Step 2: Create an Amazon Managed Service for Prometheus Workspace
+
+* create an Amazon Managed Service for Prometheus workspace `my-prometheus` to store metrics
+* update above config file's `prometheus_remote_write` `uri` to the created workspace's remote write url endpoint
+
+### Step 3: Upload config file to S3
+
+* create the S3 bucket `your-bucket` to store config files
+* upload above config file to this bucket
+
+### Step 4: Create the ECS Task
+
+* create the ECS Task using provided `task-definition.json`, which using the Fluent Bit image with init tag
+* change the `taskRoleArn` and `executionRoleArn` to your own role ARN
+* change the `environment` part in the task definition FireLens configuration, copy the ARN of config files and paste it as environment variable's value. The name of environment variable requires to use the prefix `aws_fluent_bit_init_s3_`
+
+### Step 5: View the metrics with Grafana
+
+To view the metrics sent to Prometheus, consider creating an Amazon Managed Grafana workspace and adding the Amazon Managed Service for Prometheus workspace as it's data source. Refer to following [documentation](https://docs.aws.amazon.com/grafana/latest/userguide/AMP-adding-AWS-config.html) for more information.

--- a/examples/fluent-bit/amazon-managed-service-for-prometheus/config-files/fluent-bit.conf
+++ b/examples/fluent-bit/amazon-managed-service-for-prometheus/config-files/fluent-bit.conf
@@ -1,16 +1,18 @@
 # FireLens Example: Prometheus forward metrics - using the Fluent Bit image with init tag
 
-# Scape node metrics every 20 seconds (use any metrics input plugin)
+# Scrape node metrics every 20 seconds (collect metrics using any metrics input plugin)
+# See the docs for more information: https://docs.fluentbit.io/manual/pipeline/inputs/node-exporter-metrics
 [INPUT]
     Name                        node_exporter_metrics
     Tag                         node_metrics
     Scrape_interval             20
 
 # Send metrics to AMP via Remote Write
+# See the docs for more information: https://docs.fluentbit.io/manual/pipeline/outputs/prometheus-remote-write
 [OUTPUT]
     Name prometheus_remote_write
     Match node_metrics
-    Host aps-workspaces.us-west-2.amazonaws.com
+    Host aps-workspaces.< region >.amazonaws.com
     Port 443
     Uri /workspaces/< my-amp-workspace-id >/api/v1/remote_write
     AWS_Auth On

--- a/examples/fluent-bit/amazon-managed-service-for-prometheus/config-files/fluent-bit.conf
+++ b/examples/fluent-bit/amazon-managed-service-for-prometheus/config-files/fluent-bit.conf
@@ -1,0 +1,21 @@
+# FireLens Example: Prometheus forward metrics - using the Fluent Bit image with init tag
+
+# Scape node metrics every 20 seconds (use any metrics input plugin)
+[INPUT]
+    Name                        node_exporter_metrics
+    Tag                         node_metrics
+    Scrape_interval             20
+
+# Send metrics to AMP via Remote Write
+[OUTPUT]
+    Name prometheus_remote_write
+    Match node_metrics
+    Host aps-workspaces.us-west-2.amazonaws.com
+    Port 443
+    Uri /workspaces/< my-amp-workspace-id >/api/v1/remote_write
+    AWS_Auth On
+    AWS_region us-west-2
+    Tls On
+    Tls.verify On
+    add_label app my-ecs-app
+    add_label color blue

--- a/examples/fluent-bit/amazon-managed-service-for-prometheus/permissions.json
+++ b/examples/fluent-bit/amazon-managed-service-for-prometheus/permissions.json
@@ -1,0 +1,37 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AllowRemoteWritePrometheus",
+            "Effect": "Allow",
+            "Action": [
+                "aps:RemoteWrite"
+            ],
+            "Resource": "arn:aws:aps:<region>:<account>:workspace/ws-<amazon-prometheus-ws-id>"
+        },
+        {
+            "Sid": "AllowAccessInitTaskConfig",
+            "Effect": "Allow",
+            "Action": [
+                "s3:PutObject",
+                "s3:GetObject",
+                "s3:GetBucketLocation"
+            ],
+            "Resource": [
+                "arn:aws:s3:::your-bucket",
+                "arn:aws:s3:::your-bucket/*"
+            ]
+        },
+        {
+            "Sid": "AllowWriteCloudWatchLogs",
+            "Effect": "Allow",
+            "Action": [
+                "logs:CreateLogGroup",
+                "logs:PutLogEvents",
+                "logs:CreateLogStream",
+                "logs:DescribeLogStreams"
+            ],
+            "Resource": "*"
+        }
+    ]
+}

--- a/examples/fluent-bit/amazon-managed-service-for-prometheus/task-definition.json
+++ b/examples/fluent-bit/amazon-managed-service-for-prometheus/task-definition.json
@@ -1,0 +1,48 @@
+{
+    "family": "firelens-example-amazon-managed-service-for-prometheus",
+    "taskRoleArn": "arn:aws:iam::xxxxxxxxxx:role/ecs_task_iam_role",
+    "executionRoleArn": "arn:aws:iam::xxxxxxxxxx:role/ecs_task_execution_role",
+    "containerDefinitions": [
+        {
+            "essential": true,
+            "image": "public.ecr.aws/aws-observability/aws-for-fluent-bit:init-latest",
+            "name": "log_router",
+            "firelensConfiguration": {
+                "type": "fluentbit"
+            },
+            "logConfiguration": {
+                "logDriver": "awslogs",
+                "options": {
+                    "awslogs-group": "firelens-container",
+                    "awslogs-region": "us-west-2",
+                    "awslogs-create-group": "true",
+                    "awslogs-stream-prefix": "firelens-init"
+                }
+            },
+            "environment": [
+                {
+                    "name": "aws_fluent_bit_init_s3_1",
+                    "value": "arn:aws:s3:::your-bucket/fluent-bit.conf"
+                }
+            ],
+            "memoryReservation": 50
+        },
+        {
+            "essential": true,
+            "name": "my-app",
+            "image": "nginx",
+            "logConfiguration": {
+                "logDriver": "awsfirelens",
+                "options": {
+                    "Name": "cloudwatch",
+                    "region": "us-west-2",
+                    "log_group_name": "/aws/ecs/containerinsights/$(ecs_cluster)/application",
+                    "auto_create_group": "true",
+                    "log_stream_name": "$(ecs_task_id)",
+                    "retry_limit": "2"
+                }
+            },
+            "memoryReservation": 100
+        }
+    ]
+}

--- a/examples/fluent-bit/cloudwatchlogs-emf/emf-over-tcp/extra.conf
+++ b/examples/fluent-bit/cloudwatchlogs-emf/emf-over-tcp/extra.conf
@@ -24,3 +24,6 @@
     log_stream_prefix   from-fluent-bit-
     auto_create_group   true
     log_format          json/emf
+    # consider configuring more than 1 worker, up to the numer of cores on your host
+    # to accommodate higher throughput logging. Only 2.32+ supports multi-worker
+    workers             1

--- a/examples/fluent-bit/cloudwatchlogs-emf/emf-over-tcp/task-definition-bridge.json
+++ b/examples/fluent-bit/cloudwatchlogs-emf/emf-over-tcp/task-definition-bridge.json
@@ -45,7 +45,8 @@
 					"log_group_name": "stdout-stderr-log-group/application",
 					"auto_create_group": "true",
 					"log_stream_prefix": "app-",
-					"retry_limit": "2"
+					"retry_limit": "2",
+					"workers": "1"
 				}
 			},
 			"memoryReservation": 100

--- a/examples/fluent-bit/cloudwatchlogs/README.md
+++ b/examples/fluent-bit/cloudwatchlogs/README.md
@@ -7,11 +7,15 @@ There are two Fluent Bit output plugins for sending to Amazon CloudWatch Logs:
 * Plugin name `cloudwatch_logs`: the newer and higher performance cloudwatch plugin built in C in the Fluent Bit upstream code base. It has more limited log group and stream name templating support. See its [documentation](https://docs.fluentbit.io/manual/pipeline/outputs/cloudwatch). This directory contains an example task definition for the high performance plugin without templating. The log stream name will be set to be `{log_stream_prefix}{log tag}` and [FireLens sets the log tag](https://github.com/aws/aws-for-fluent-bit/blob/mainline/troubleshooting/debugging.md#firelens-tag-and-match-pattern-and-generated-config) to be `{container name in task definition}-firelens-{task ID}`. So the log stream name for this example will be `stdout-stderr-app-firelens-{task ID}`. 
 
 
-For more on the AWS Go outputs vs AWS C outputs, check out the [FAQ entry in our debugging guide](https://github.com/aws/aws-for-fluent-bit/blob/mainline/troubleshooting/debugging.md#aws-go-plugins-vs-aws-core-c-plugins). 
+For more on the AWS Go outputs vs AWS C outputs, check out the [FAQ entry in our debugging guide](https://github.com/aws/aws-for-fluent-bit/blob/mainline/troubleshooting/debugging.md#aws-go-plugins-vs-aws-core-c-plugins).
 
 #### Recommended cloudwatch_logs configuration options
 
 To minimize the possibility of log loss when sending to CloudWatch, consider using the recommended configuration outlined in the [CloudWatch Recommendations](https://github.com/aws/aws-for-fluent-bit/issues/340) issue.
+
+#### High throughput logging to CloudWatch Logs via multiple workers
+
+As of AWS For Fluent Bit `2.32.0`, the `cloudwatch_out` plugin supports high througpht logging via multiple workers. Set the `workers` option to a high value such as `5`. Fluent Bit will spin up the specified number of workers as threads which will take advantage of concurrency. For best performance, the number of workers should be at least the number of cores on the host. AWS For Fluent Bit `2.31.12` and prior does not support multiple workers and should should only use `0` and `1` workers.
 
 ### What if I just want the raw log line from the container to appear in CloudWatch?
 

--- a/examples/fluent-bit/cloudwatchlogs/README.md
+++ b/examples/fluent-bit/cloudwatchlogs/README.md
@@ -15,7 +15,7 @@ To minimize the possibility of log loss when sending to CloudWatch, consider usi
 
 #### High throughput logging to CloudWatch Logs via multiple workers
 
-As of AWS For Fluent Bit `2.32.0`, the `cloudwatch_out` plugin supports high througpht logging via multiple workers. Set the `workers` option to a high value such as `5`. Fluent Bit will spin up the specified number of workers as threads which will take advantage of concurrency. For best performance, the number of workers should be at least the number of cores on the host. AWS For Fluent Bit `2.31.12` and prior does not support multiple workers and should should only use `0` and `1` workers.
+As of AWS For Fluent Bit `2.32.0`, the `cloudwatch_logs` plugin supports high throughput logging via multiple workers. Set the `workers` option to an integer value, such as `5`, indicating the number of worker threads dedicated to processing output data to CloudWatch Logs concurrently. To optimize for high throughput logging, consider setting the number of workers the number of cores on the host. AWS For Fluent Bit `2.31.12` and prior does not support multiple workers, and `workers` should be set to `1`.
 
 ### What if I just want the raw log line from the container to appear in CloudWatch?
 

--- a/examples/fluent-bit/cloudwatchlogs/task-definition-cloudwatch_logs.json
+++ b/examples/fluent-bit/cloudwatchlogs/task-definition-cloudwatch_logs.json
@@ -33,7 +33,8 @@
 					"log_group_name": "/aws/ecs/containerinsights/application",
 					"auto_create_group": "true",
 					"log_stream_name": "stdout-stderr-",
-					"retry_limit": "2"
+					"retry_limit": "2",
+					"workers": "1"
 				}
 			},
 			"memoryReservation": 100

--- a/examples/fluent-bit/oomkill-prevention/filesystem.conf
+++ b/examples/fluent-bit/oomkill-prevention/filesystem.conf
@@ -41,3 +41,6 @@
     retry_limit 2
     # limit the filesystem storage that this output can use
     storage.total_limit_size 1G
+    # consider configuring more than 1 worker, up to the numer of cores on your host
+    # to accommodate higher throughput logging. Only 2.32+ supports multi-worker
+    workers             1

--- a/examples/fluent-bit/oomkill-prevention/firelens-full-filesystem-example/fluent-bit-image/extra.conf
+++ b/examples/fluent-bit/oomkill-prevention/firelens-full-filesystem-example/fluent-bit-image/extra.conf
@@ -50,3 +50,6 @@
     retry_limit 2
     # limit the filesystem storage that this output can use
     storage.total_limit_size 1G
+    # consider configuring more than 1 worker, up to the numer of cores on your host
+    # to accommodate higher throughput logging. Only 2.32+ supports multi-worker
+    workers             1

--- a/examples/fluent-bit/oomkill-prevention/firelens-full-memory-example/fluent-bit-image/extra.conf
+++ b/examples/fluent-bit/oomkill-prevention/firelens-full-memory-example/fluent-bit-image/extra.conf
@@ -47,3 +47,6 @@
     log_stream_name /logs/${HOSTNAME}
     auto_create_group true
     retry_limit 2
+    # consider configuring more than 1 worker, up to the numer of cores on your host
+    # to accommodate higher throughput logging. Only 2.32+ supports multi-worker
+    workers 1

--- a/examples/fluent-bit/send-fb-internal-metrics-to-cw/extra.conf
+++ b/examples/fluent-bit/send-fb-internal-metrics-to-cw/extra.conf
@@ -74,4 +74,6 @@
     log_stream_name ${HOSTNAME}-fb-internal-metrics
     auto_create_group On
     retry_limit 2
+    # consider configuring more than 1 worker, up to the numer of cores on your host
+    # to accommodate higher throughput logging. Only 2.32+ supports multi-worker
     workers 1


### PR DESCRIPTION
Example Updates
1. Add cloudwatch_logs note on using multiple workers for higher throughput in version 2.32.0 and beyond
2. Add Amazon Managed Prometheus comment to explain how to send metrics to your own personal amazon prometheus workspace, and grafana setup link to aws docs

[Related to the 2.32.0 update](https://github.com/aws/aws-for-fluent-bit/pull/733)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
