### PR TITLE
For example s3 bucket, use reserved 'amzn-s3-demo' prefix

### DIFF
--- a/examples/splitting-log-streams/fluentd/task_definition.json
+++ b/examples/splitting-log-streams/fluentd/task_definition.json
@@ -15,7 +15,7 @@
 				"type": "fluentd",
 				"options": {
 					"config-file-type": "s3",
-					"config-file-value": "arn:aws:s3:::firelens-config-bucket/rewrite-tag.conf"
+					"config-file-value": "arn:aws:s3:::amzn-s3-demo-CHANGE-ME-TO-YOUR-BUCKET/rewrite-tag.conf"
 				}
 			},
 			"logConfiguration": {


### PR DESCRIPTION


*Description of changes:*

This prefix is an s3 reserved prefix, which means that this bucket can't be used by customers who deploy this task def without modifying it. Customers need to modify this to ensure that the task def pulls config from their own bucket.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
